### PR TITLE
add missing translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1657,7 +1657,7 @@ Other Style Guides
 
   <a name="13.1"></a>
   <a name="variables--const"></a>
-  - [13.1](#variables--const)  用`const`声明变量。不这样做会导致全局变量。 我们想要避免污染全局命名空间。首长这样警告我们。 eslint: [`no-undef`](http://eslint.org/docs/rules/no-undef) [`prefer-const`](http://eslint.org/docs/rules/prefer-const)
+  - [13.1](#variables--const)  用`const`或`let`声明变量。不这样做会导致全局变量。 我们想要避免污染全局命名空间。首长这样警告我们。 eslint: [`no-undef`](http://eslint.org/docs/rules/no-undef) [`prefer-const`](http://eslint.org/docs/rules/prefer-const)
 
     ```javascript
     // bad


### PR DESCRIPTION
In English version: `Always use const or let to declare variables. Not doing so will result in global variables...`
In Chinese (Simplified) version: `用 const 声明变量。不这样做会导致全局变量...`
I'm think maybe there is a missing translation here.